### PR TITLE
feat: fine tune nginx configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,14 @@ FROM nginxinc/nginx-unprivileged:1.29-alpine-otel
 
 RUN rm /etc/nginx/conf.d/default.conf
 
-COPY static /var/www
-
-# Default Nginx config
 COPY nginx/nginx.conf /etc/nginx/nginx.conf
+COPY nginx/*.template /etc/nginx/templates/
+COPY --chmod=+x scripts/*.sh /docker-entrypoint.d/
 
-COPY nginx/themes.conf.template /etc/nginx/templates/themes.conf.template
-COPY nginx/otel.conf.template /etc/nginx/templates/otel.conf.template
-
-COPY scripts/25-rewrite-otel-conf-if-disabled.sh /docker-entrypoint.d/
-
+COPY static /var/www
 
 ENV NGINX_ENVSUBST_OUTPUT_DIR=/tmp \
     NGINX_ENVSUBST_TEMPLATE_DIR=/etc/nginx/templates \
     OTEL_SERVICE_NAME=ai-dial-chat-themes
 
+EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -20,19 +20,17 @@
   - [Run](#run)
 - [Helm Deployment and Configuration](#helm-deployment-and-configuration)
 - [Working with Themes](#working-with-themes)
-    - [Add Theme](#add-theme)
-    - [Customize Image URLs](#customize-image-urls)
-    - [Customize Theme Colors](#customize-theme-colors)
-    - [Colors for the Sign in Page (authColors)](#colors-for-the-sign-in-page-authColors)
-    - [Customizing Banner Images (banners)](#customizing-banner-images-banners)
-
----
+  - [Add Theme](#add-theme)
+  - [Customize Image URLs](#customize-image-urls)
+  - [Customize Theme Colors](#customize-theme-colors)
+  - [Colors for the Sign in Page (authColors)](#colors-for-the-sign-in-page-authcolors)
+  - [Customizing Banner Images (banners)](#customizing-banner-images-banners)
 
 ## Overview
 
 > [!NOTE]
-> A theme is a collection of static resources including images, fonts, and color palettes that you can utilize to personalize the appearance of your [AI DIAL Chat](https://github.com/epam/ai-dial-chat) application. These resources can be stored anywhere and accessed by the chat application via the internet. We provide the AI DIAL Chat Themes service as a convenient method for hosting these static resources and making them accessible for the chat application(s). However, you have the flexibility to choose your own method for accomplishing this. 
-> 
+> A theme is a collection of static resources including images, fonts, and color palettes that you can utilize to personalize the appearance of your [AI DIAL Chat](https://github.com/epam/ai-dial-chat) application. These resources can be stored anywhere and accessed by the chat application via the internet. We provide the AI DIAL Chat Themes service as a convenient method for hosting these static resources and making them accessible for the chat application(s). However, you have the flexibility to choose your own method for accomplishing this.
+>
 > This approach, having static resources externally, enables developers and designers to work concurrently and implement changes to themes without having to rebuild the chat application Docker image.
 
 > [!IMPORTANT]
@@ -41,7 +39,6 @@
 > [!TIP]
 > Chat application users can then select themes in [user settings](https://github.com/epam/ai-dial/blob/main/docs/user-guide.md#user-settings).
 
----
 ## OTEL Integration
 
 Added for your Env variables the next variables with the proper values. Trigger a redeploy of your Themes instance.
@@ -52,13 +49,13 @@ Added for your Env variables the next variables with the proper values. Trigger 
 ```
 
 > [!TIP]
-> Refer to the Offical [OTLP Exporter Configuration](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/) documentation for more details.
+> Refer to the Official [OTLP Exporter Configuration](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/) documentation for more details.
 
 > [!TIP]
 > Refer to the DIAL [Observability and Monitoring](https://docs.dialx.ai/tutorials/devops/observability-config) documentation for more details.
 
 > [!TIP]
-> Refer to the Offical [Module ngx_otel_module](https://nginx.org/en/docs/ngx_otel_module.html#variables) documentation for more details.
+> Refer to the Official [Module ngx_otel_module](https://nginx.org/en/docs/ngx_otel_module.html#variables) documentation for more details.
 
 ## Set Up Developer Environment
 
@@ -74,28 +71,22 @@ make build
 
 ### Run
 
-Execute this command to run the Docker container and bind the container port 8080 to the host network interface `localhost:80`
+Execute this command to run the Docker container available at `http://localhost:8080`:
 
 ```bash
 make run
 ```
 
----
-
 ## Helm Deployment and Configuration
 
 1. You can deploy AI DIAL Chat Themes service using a common [dial](https://github.com/epam/ai-dial-helm/tree/main/charts/dial) Helm chart or using a stand-alone chart [dial-extension](https://github.com/epam/ai-dial-helm/tree/main/charts/dial-extension).
-    
-> [!TIP]
-> Refer to [AI DIAL Helm](https://github.com/epam/ai-dial-helm) to learn about the deployment options and view the examples of charts.
 
-2. In the [config.json](./static/config.json) file, you can define and configure custom themes or use (edit) default ones. Images can be stored in the **static** folder as well. However, you can store images anywhere and provide URLs in the config file.
+    > [!TIP]
+    > Refer to [AI DIAL Helm](https://github.com/epam/ai-dial-helm) to learn about the deployment options and view the examples of charts.
 
-3. Further, it is necessary to configure AI DIAL Chat to access the static resources and the themes configuration. To do that, add `THEMES_CONFIG_HOST` to the chat configuration - refer to [documentation](https://github.com/epam/ai-dial-chat/blob/development/apps/chat/README.md) for details. `THEMES_CONFIG_HOST` environment variable contains the URL to your nginx server with the configuration and images (this is the case when you use AI DIAL Chat Themes to provide static resoures for the chat application). This ensures that the application fetches your configuration file during loading. If the environment variable is not provided, [default themes and model icons]((./static/config.json)) will be applied.
-
-4. After applying changes, it is necessary to redeploy the themes server. Changes will take effect automatically on the chat UI after 24hrs or upon the page reload. All the configured themes will be available in the chat application in [user settings](https://github.com/epam/ai-dial/blob/main/docs/user-guide.md#user-settings).
-
----
+1. In the [config.json](./static/config.json) file, you can define and configure custom themes or use (edit) default ones. Images can be stored in the **static** folder as well. However, you can store images anywhere and provide URLs in the config file.
+1. Further, it is necessary to configure AI DIAL Chat to access the static resources and the themes configuration. To do that, add `THEMES_CONFIG_HOST` to the chat configuration - refer to [documentation](https://github.com/epam/ai-dial-chat/blob/development/apps/chat/README.md) for details. `THEMES_CONFIG_HOST` environment variable contains the URL to your nginx server with the configuration and images (this is the case when you use AI DIAL Chat Themes to provide static resources for the chat application). This ensures that the application fetches your configuration file during loading. If the environment variable is not provided, [default themes and model icons]((./static/config.json)) will be applied.
+1. After applying changes, it is necessary to redeploy the themes server. Changes will take effect automatically on the chat UI after 24hrs or upon the page reload. All the configured themes will be available in the chat application in [user settings](https://github.com/epam/ai-dial/blob/main/docs/user-guide.md#user-settings).
 
 ## Working with Themes
 
@@ -149,7 +140,7 @@ The URL for `app-logo` will be recognized as a relative URL and transformed into
 ```
 
 > [!IMPORTANT]
-> Specify a full path to your images (e.g. `https://some-path.svg`) if you are hosting them at the external source; otherwise, a path will be recognized as a relative URL and transformed into `{{host}}/app-logo.svg`. 
+> Specify a full path to your images (e.g. `https://some-path.svg`) if you are hosting them at the external source; otherwise, a path will be recognized as a relative URL and transformed into `{{host}}/app-logo.svg`.
 
 ### Customize Theme Colors
 
@@ -200,9 +191,9 @@ The URL for `app-logo` will be recognized as a relative URL and transformed into
 
 > [!NOTE]
 > To customize banner images, you can provide image URLs inside the desired theme object:
-> 
+>
 > 1. Locate or create the `banners` property inside the desired theme object in config.json.
-> 2. Update or add values for `my-workspace-banner` and `marketplace-banner` with the relative path or full URL of your custom images.
+> 1. Update or add values for `my-workspace-banner` and `marketplace-banner` with the relative path or full URL of your custom images.
 
 ```json
 {
@@ -218,5 +209,3 @@ The URL for `app-logo` will be recognized as a relative URL and transformed into
   ]
 }
 ```
-
----

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -17,28 +17,45 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
-    # Added
+    # A predefined "combined" format with http_x_forwarded_for added
     log_format main
         '$remote_addr - $remote_user [$time_local] "$request" '
         '$status $body_bytes_sent "$http_referer" '
         '"$http_user_agent" "$http_x_forwarded_for"';
-
     access_log /dev/stdout main;
-
-    sendfile on;
 
     keepalive_timeout 65;
 
+    # Efficient zero-copy to buffer file transmission
+    sendfile on;
+    # send HTTP response headers in one TCP packet with the body chunk, do not wait for a new one
+    tcp_nopush on;
+
+    # Gzip configuration
     gzip on;
-    gzip_http_version 1.0;
-    gzip_min_length 500;
-    gzip_buffers 4 8k;
+    # Set the `Vary: Accept-Encoding` header to force proxies to store compressed and uncompressed versions
+    gzip_vary on;
+    # Don't compress small responses, as the overhead of compression may outweigh the benefits
+    gzip_min_length 1024;
     gzip_comp_level 4;
+    # A pretty comprehensive list of content mime types that we want to compress;
+    # don't include text/html - it is included by default and will result in a warning
+    gzip_types text/plain
+        text/css
+        text/xml
+        application/javascript
+        application/json
+        application/xml
+        application/xhtml+xml
+        application/rss+xml
+        application/atom+xml
+        image/svg+xml
+        image/x-icon;
+
+    # Hide nginx version as a security best practice
     server_tokens off;
 
-    # Themes (always)
     include /tmp/themes.conf;
-    
-    # OTEL (conditions in template)
+    # OTEL configuration is always included; however, it's _actually_ enabled/disabled by 25-rewrite-otel-conf-if-disabled.sh script on startup
     include /tmp/otel.conf;
 }

--- a/nginx/otel.conf.template
+++ b/nginx/otel.conf.template
@@ -9,9 +9,10 @@ otel_exporter {
 
 otel_trace_context inject;
 
-log_format main_otel '$remote_addr - $remote_user [$time_local] "$request" '
-                     '$status $body_bytes_sent "$http_referer" '
-                     '"$http_user_agent" "$http_x_forwarded_for" '
-                     'trace_id=$otel_trace_id span_id=$otel_span_id';
+log_format main_otel
+    '$remote_addr - $remote_user [$time_local] "$request" '
+    '$status $body_bytes_sent "$http_referer" '
+    '"$http_user_agent" "$http_x_forwarded_for" '
+    'trace_id=$otel_trace_id span_id=$otel_span_id';
 
 access_log /dev/stdout main_otel;

--- a/nginx/themes.conf.template
+++ b/nginx/themes.conf.template
@@ -1,41 +1,34 @@
 server {
     listen 8080;
-    otel_span_name "main_server_block";
-    large_client_header_buffers 4 16k;
 
     root /var/www;
 
+    otel_span_name "main_server_block";
+
+    large_client_header_buffers 4 16k;
     client_body_buffer_size 1K;
     client_header_buffer_size 1k;
     client_max_body_size 1k;
 
-    # Block download agents
-    if ($http_user_agent ~ LWP::Simple|BBBike|wget) {
-        return 403;
-    }
-
-    # Block some robots
-    if ($http_user_agent ~ msnbot|scrapbot) {
-        return 403;
-    }
-
     location / {
+        # Add cache control headers since we're serving static content only
         expires 1w;
-        sendfile on;
-        tcp_nopush on;
-        tcp_nodelay on;
+
+        # Create directory listing in JSON format - required(?) for integrations
         autoindex on;
         autoindex_format json;
-        add_header Cache-Control "public";
+
+        # Allows any origin to access resources since designed to serve public static content only
         add_header Access-Control-Allow-Origin "*";
-        
-        otel_trace_context propagate; 
+
+        otel_trace_context propagate;
     }
 
     location = /health {
         access_log off;
-        otel_trace off; 
-        add_header 'Content-Type' 'application/json';
+        otel_trace off;
+        default_type application/json;
+        add_header Cache-Control "no-store, max-age=0" always;
         return 200 '{"status":"ok"}';
     }
 }

--- a/scripts/25-rewrite-otel-conf-if-disabled.sh
+++ b/scripts/25-rewrite-otel-conf-if-disabled.sh
@@ -4,18 +4,16 @@ set -e
 
 ME="$(basename "$0")"
 
-
 entrypoint_log() {
     if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
         echo "$@"
     fi
 }
 
-
 rewrite_otel_conf_if_disabled() {
     if [ -z "${OTEL_EXPORTER_OTLP_ENDPOINT:-}" ]; then
         entrypoint_log "$ME: OTEL_EXPORTER_OTLP_ENDPOINT is not set. Rewrite /tmp/otel.conf"
-        cat > /tmp/otel.conf << 'EOF'
+        cat >/tmp/otel.conf <<'EOF'
 otel_trace off;
 
 otel_exporter {


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->
- Fine tuned NGINX configuration
    - Tuned gzip configuration:
        - Added `svg` (and other _potentially_ useful) MIME types to compress
        - Added `gzip_vary on` directive to ensure proper CDN caching
        - Removed legacy `gzip_http_version 1.0` directive in favor of default (`1.1`)
        - Removed custom `gzip_buffers` directive in favor of default (`16 8k`) - no actual savings on reduced buffers in our use case
        - Increased `gzip_min_length` from `500` to `1024` bytes - on small responses compression overhead outweigh the benefits
        - Moved `tcp_nopush`, `tcp_nodelay` options from specific location of specific server to global `http` directive
        - Dropped super naive bot filtration based on user agent - makes no sense, serving public static files
        - Dropped redundant `add_header Cache-Control` directive since `expires` in place
- Reformatted NGINX configuration files; Added comments on options where's possible
- Optimized Dockerfile instructions
- Fixed formatting in the bash script
- Fixed formatting issues in README.md


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
