### PR TITLE
ci(deps): bump epam/ai-dial-ci from 4.10.0 to 4.11.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📝 Talk in Discord
-    url: https://discord.gg/ukzj9U9tEe
+    url: https://discord.gg/jvTCQv4E4q
     about: Discuss your question in Discord

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,8 @@ updates:
       day: "wednesday"
       time: "09:00"
     commit-message:
-      # Prefix all commit messages with "chore: "
-      prefix: "chore"
+      prefix: "ci"
+      include: scope
     groups:
       ai-dial-ci:
         applies-to: version-updates

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,10 +7,4 @@
 
 <!-- Please explain the changes you made right below this line. -->
 
-### Checklist
-
-<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
-
-- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
-
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/.github/workflows/cleanup-untagged-images.yml
+++ b/.github/workflows/cleanup-untagged-images.yml
@@ -14,3 +14,6 @@ jobs:
       - uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         with:
           delete-untagged: true
+          delete-ghost-images: true # Delete indexes with no manifests
+          delete-partial-images: true # Delete indexes which refer to at least one non-existent manifest
+          delete-orphaned-images: true # Delete dangling referrers, e.g. SBOMs, signatures, etc. that refer to non-existent digest

--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -15,6 +15,7 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
       - name: Approve PR
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -14,7 +14,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.registry_package.package_version.container_metadata.tag.name == 'development' ||
       (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'development')
-    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@4.9.0
+    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@4.11.0
     with:
       gitlab-project-id: "2979"
     secrets:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -15,6 +15,6 @@ concurrency:
 
 jobs:
   pr-title-check:
-    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.9.0
+    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.11.0
     secrets:
       ACTIONS_BOT_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,4 +11,6 @@ concurrency:
 jobs:
   run_tests:
     uses: epam/ai-dial-ci/.github/workflows/generic_docker_pr.yml@4.11.0
+    with:
+      ort-enabled: false # TODO: enable ORT once the repository uses any of the supported package managers: https://oss-review-toolkit.org/ort/docs/category/package-managers
     secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,5 +10,5 @@ concurrency:
 
 jobs:
   run_tests:
-    uses: epam/ai-dial-ci/.github/workflows/generic_docker_pr.yml@4.9.0
+    uses: epam/ai-dial-ci/.github/workflows/generic_docker_pr.yml@4.11.0
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,4 +19,5 @@ jobs:
     uses: epam/ai-dial-ci/.github/workflows/generic_docker_release.yml@4.11.0
     with:
       promote: ${{ github.event_name == 'workflow_dispatch' && inputs.promote }}
+      ort-enabled: false # TODO: enable ORT once the repository uses any of the supported package managers: https://oss-review-toolkit.org/ort/docs/category/package-managers
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/generic_docker_release.yml@4.9.0
+    uses: epam/ai-dial-ci/.github/workflows/generic_docker_release.yml@4.11.0
     with:
       promote: ${{ github.event_name == 'workflow_dispatch' && inputs.promote }}
     secrets: inherit

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -5,7 +5,9 @@ on:
 jobs:
   slashCommandDispatch:
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue.pull_request }}
+    if: |
+      github.event.issue.pull_request &&
+      github.event.issue.state == 'open'
     steps:
       - name: Slash Command Dispatch
         id: scd


### PR DESCRIPTION
### Description of changes

- bump epam/ai-dial-ci from `4.10.0` to `4.11.0`
- align workflows with recommended configuration; this delivers minor fixes
- disable ORT - nothing to scan